### PR TITLE
fix: add AUTO_INCREMENT for primary key

### DIFF
--- a/core/triggers/interface_99_modCTPT_CTPTTriggers.class.php
+++ b/core/triggers/interface_99_modCTPT_CTPTTriggers.class.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2022      Nick Fragoulis
  * Copyright (C) 2022	   Nikos Drosis            <ndrosis@sysaid.gr>
+ * Copyright (C) 2024      Stefan Mayer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/core/triggers/interface_99_modCTPT_CTPTTriggers.class.php
+++ b/core/triggers/interface_99_modCTPT_CTPTTriggers.class.php
@@ -230,7 +230,7 @@ class InterfaceCTPTTriggers extends DolibarrTriggers
 
 			$sql = "
                         CREATE TEMPORARY TABLE ".MAIN_DB_PREFIX."temp (
-                        `id` int(11) NOT NULL,
+                        `id` int(11) NOT NULL AUTO_INCREMENT,
                         `rowid` int(11),
                         `fk_soc` int(11),
                         `series` int(11),
@@ -268,7 +268,7 @@ class InterfaceCTPTTriggers extends DolibarrTriggers
 
 			$sql = "
                         CREATE TEMPORARY TABLE ".MAIN_DB_PREFIX."temp (
-                        `id` int(11) NOT NULL,
+                        `id` int(11) NOT NULL AUTO_INCREMENT,
                         `rowid` int(11),
                         `fk_soc` int(11),
                         `series` int(11),


### PR DESCRIPTION
Add `AUTO_INCREMENT` for primary key. Otherwise it creates the error `#1364 - Field 'id' doesn't have a default value`, when you execute the `INSERT INTO` query.

This fixes issue #10.

Edit: It seems this fix was already implemented by pull request #6, but reverted by commit f29e089.